### PR TITLE
add support for loading of .NET executables that have already been loaded outside of dotnetfile

### DIFF
--- a/dotnetfile/parser.py
+++ b/dotnetfile/parser.py
@@ -79,7 +79,7 @@ class DotNetPEParser(PE):
         if not self.is_dotnet_file():
             raise CLRFormatError('File is not a .NET assembly.')
 
-        if not self.is_metadata_header_complete_and_valid(path):
+        if not self.is_metadata_header_complete_and_valid(file_ref):
             raise CLRFormatError('CLR header of file is most likely corrupt.')
 
         self.logger = get_logger('extended_pe_logger', level=log_level)


### PR DESCRIPTION
Currently dotnetfile only loads .NET executables via their file path. This pull adds the ability for dotnetfile to load a .NET executables via bytes-type object. For example:

```
$ python3
>>> from dotnetfile import DotNetPE
>>> dotnet_file = DotNetPE('0a5dc3b6669cf31e8536c59fe1315918eb4ecfd87998445e2eeb8fed64bd2f2c')
>>> print(f'Number of streams: {dotnet_file.get_number_of_streams()}')
Number of streams: 5
>>> 
>>> file_data = None
>>> with open('0a5dc3b6669cf31e8536c59fe1315918eb4ecfd87998445e2eeb8fed64bd2f2c', 'rb') as hFile:
...     file_data = hFile.read()
... 
>>> dotnet_file2 = DotNetPE(file_data)
>>> print(f'Number of streams: {dotnet_file2.get_number_of_streams()}')
Number of streams: 5
>>> 
```