### PR TITLE
Handle of PathLike objects for DotNetPEParser

### DIFF
--- a/dotnetfile/parser.py
+++ b/dotnetfile/parser.py
@@ -66,7 +66,7 @@ class DotNetPEParser(PE):
     """
     Handy reference: https://www.ntcore.com/files/dotnetformat.htm
     """
-    def __init__(self, file_ref, parse=True, log_level=logging.INFO, *args, **kwargs):
+    def __init__(self, file_ref: PathLike, parse: bool = True, log_level: int = logging.INFO, *args, **kwargs):
 
         if isinstance(file_ref, bytes):
             super().__init__(data=file_ref, *args, **kwargs)
@@ -168,7 +168,7 @@ class DotNetPEParser(PE):
 
         return result
 
-    def is_metadata_header_complete_and_valid(self, file_ref: str | bytes) -> bool:
+    def is_metadata_header_complete_and_valid(self, file_ref: PathLike) -> bool:
         """
         Check if the metadata data is complete according to the values in the Cor20 header
         """


### PR DESCRIPTION
## Summary

Fix to handle path objects such as `pathlib.Path` in `DotNetPEParser`, which currently raise an error (see below).

## Previous behavior
```python
>>>from pathlib import Path
>>>import dotnetfile
>>>filepath = Path("<path_2_file>")
>>>dotnetfile.DotNetPE(filepath)
~/.virtualenvs/dotnet/lib/python3.7/site-packages/dotnetfile-0.1.0-py3.7.egg/dotnetfile/dotnetfile.py in __init__(self, path)
    161 class DotNetPE(DotNetPEParser):
    162     def __init__(self, path):
--> 163         super().__init__(path)
    164         self.AntiMetadataAnalysis = AntiMetadataAnalysis(self)
    165         self.Cor20Header = Cor20Header(self)

~/.virtualenvs/dotnet/lib/python3.7/site-packages/dotnetfile-0.1.0-py3.7.egg/dotnetfile/parser.py in __init__(self, file_ref, parse, log_level, *args, **kwargs)
     77         }
     78 
---> 79         if not self.is_dotnet_file():
     80             raise CLRFormatError('File is not a .NET assembly.')
     81 

~/.virtualenvs/dotnet/lib/python3.7/site-packages/dotnetfile-0.1.0-py3.7.egg/dotnetfile/parser.py in is_dotnet_file(self)
    153         dotnet_data_dir = DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR']
    154 
--> 155         if self.is_dotnet_data_directory_hidden():
    156             result = True
    157         else:

~/.virtualenvs/dotnet/lib/python3.7/site-packages/dotnetfile-0.1.0-py3.7.egg/dotnetfile/parser.py in is_dotnet_data_directory_hidden(self)
    123 
    124         dotnet_dir_number = DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR']
--> 125         number_of_rva_and_sizes = self.OPTIONAL_HEADER.NumberOfRvaAndSizes
    126 
    127         try:

AttributeError: 'DotNetPE' object has no attribute 'OPTIONAL_HEADER'
```

This error was due to a bad handling of variable `file_ref` used to instantiate DotNetPEParser.

