### PR TITLE
Fixed example code typos in the documentation

### DIFF
--- a/docs/api_documentation/header/cor20/index.html
+++ b/docs/api_documentation/header/cor20/index.html
@@ -236,7 +236,7 @@
     </h3>
 </doc-anchor-target>
 <div class="codeblock-wrapper"><doc-codeblock>
-<pre class="language-python"><code v-pre class="language-python">Cor20Header.entrypoint_exists() -&gt; bool</code></pre>
+<pre class="language-python"><code v-pre class="language-python">Cor20Header.entry_point_exists() -&gt; bool</code></pre>
 </doc-codeblock></div>
 <p>The <code v-pre>Cor20</code> header has a field named <code v-pre>EntryPointToken</code>. This field contains the token of the managed entry point if not <code v-pre>0</code>. The token encodes information in which row of the <code v-pre>MethodDef</code> table the entry point is located.</p>
 <div class="flex mb-6">
@@ -269,7 +269,7 @@ from dotnetfile import DotNetPE
 dotnet_file = DotNetPE('/Users/&lt;username&gt;/my_dotnet_assembly.exe')
 
 # Print out if .NET assembly has a managed entry point
-print(f'Has managed entry point: {dotnet_file.Cor20Header.entrypoint_exists()}')</code></pre>
+print(f'Has managed entry point: {dotnet_file.Cor20Header.entry_point_exists()}')</code></pre>
 </doc-codeblock></div>
 <hr />
 <doc-anchor-target id="get-entry-point-information">

--- a/docs/api_documentation/tables/implmap/index.html
+++ b/docs/api_documentation/tables/implmap/index.html
@@ -263,7 +263,7 @@ if dotnet_file.metadata_table_exists('ImplMap'):
     unmanaged_functions = dotnet_file.ImplMap.get_unmanaged_functions()
 
     # Print out the function names
-    for unamanaged_function in unmanaged_functions:
+    for unmanaged_function in unmanaged_functions:
         print(f'{unmanaged_function}')</code></pre>
 </doc-codeblock></div>
 


### PR DESCRIPTION
While learning about this library, I noticed there were a couple of typos in the example code snippets in the documentation. Just figured I'd send a quick PR to fix those I encountered.