### PR TITLE
Fixed doc typo example get_user_stream_strings

### DIFF
--- a/docs/api_documentation/general/index.html
+++ b/docs/api_documentation/general/index.html
@@ -1065,7 +1065,7 @@ from dotnetfile import DotNetPE
 dotnet_file = DotNetPE('/Users/&lt;username&gt;/my_dotnet_assembly.exe')
 
 # Get all strings of the #US stream
-us_stream_strings = dotnet_file.get_us_stream_strings()
+us_stream_strings = dotnet_file.get_user_stream_strings()
 
 # Print out each library name
 for string in us_stream_strings:


### PR DESCRIPTION
Fixed typo in documentation

Issue: https://github.com/pan-unit42/dotnetfile/issues/6